### PR TITLE
Database type improvements

### DIFF
--- a/godynamo.go
+++ b/godynamo.go
@@ -128,3 +128,39 @@ func goTypeToDynamodbType(typ reflect.Type) string {
 	}
 	return ""
 }
+
+// nameFromAttributeValue returns the name of the attribute value.
+// e.g.
+// types.AttributeValueMemberB -> "B"
+// types.AttributeValueMemberBOOL -> "BOOL"
+func nameFromAttributeValue(v interface{}) string {
+	// De-reference pointer
+	if reflect.TypeOf(v).Kind() == reflect.Ptr {
+		v = reflect.ValueOf(v).Elem().Interface()
+	}
+
+	switch v.(type) {
+	case types.AttributeValueMemberB:
+		return "B"
+	case types.AttributeValueMemberBOOL:
+		return "BOOL"
+	case types.AttributeValueMemberBS:
+		return "BS"
+	case types.AttributeValueMemberL:
+		return "L"
+	case types.AttributeValueMemberM:
+		return "M"
+	case types.AttributeValueMemberN:
+		return "N"
+	case types.AttributeValueMemberNS:
+		return "NS"
+	case types.AttributeValueMemberNULL:
+		return "NULL"
+	case types.AttributeValueMemberS:
+		return "S"
+	case types.AttributeValueMemberSS:
+		return "SS"
+	}
+	return ""
+
+}

--- a/godynamo_test.go
+++ b/godynamo_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
 func Test_OpenDatabase(t *testing.T) {
@@ -102,4 +104,46 @@ func TestDriver_Close(t *testing.T) {
 	if err := db.Close(); err != nil {
 		t.Fatalf("%s failed: %s", testName, err)
 	}
+}
+
+func TestNameFromAttributeValue(t *testing.T) {
+	testCases := []struct {
+		name string
+		av   types.AttributeValue
+		want string
+	}{
+		{
+			name: "string",
+			av:   &types.AttributeValueMemberS{Value: "foo"},
+			want: "S",
+		},
+		{
+			name: "number",
+			av:   &types.AttributeValueMemberN{Value: "123"},
+			want: "N",
+		},
+		{
+			name: "binary",
+			av:   &types.AttributeValueMemberB{Value: []byte("foo")},
+			want: "B",
+		},
+		{
+			name: "string set",
+			av:   &types.AttributeValueMemberSS{Value: []string{"foo", "bar"}},
+			want: "SS",
+		},
+		{
+			name: "number set",
+			av:   &types.AttributeValueMemberNS{Value: []string{"123", "456"}},
+			want: "NS",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nameFromAttributeValue(tc.av); got != tc.want {
+				t.Errorf("NameFromAttributeValue() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
 }

--- a/stmt.go
+++ b/stmt.go
@@ -266,6 +266,9 @@ func (r *ResultResultSet) init() *ResultResultSet {
 	if r.columnTypes == nil {
 		r.columnTypes = make(map[string]reflect.Type)
 	}
+	if r.columnSourceTypes == nil {
+		r.columnSourceTypes = make(map[string]string)
+	}
 	r.count = len(r.stmtOutput.Items)
 	colMap := make(map[string]bool)
 	for _, item := range r.stmtOutput.Items {

--- a/stmt.go
+++ b/stmt.go
@@ -250,12 +250,13 @@ func (r *ResultNoResultSet) RowsAffected() (int64, error) {
 
 // ResultResultSet captures the result from statements that expect a ResultSet to be returned.
 type ResultResultSet struct {
-	err         error
-	count       int
-	stmtOutput  *dynamodb.ExecuteStatementOutput
-	cursorCount int
-	columnList  []string
-	columnTypes map[string]reflect.Type
+	err               error
+	count             int
+	stmtOutput        *dynamodb.ExecuteStatementOutput
+	cursorCount       int
+	columnList        []string
+	columnTypes       map[string]reflect.Type
+	columnSourceTypes map[string]string
 }
 
 func (r *ResultResultSet) init() *ResultResultSet {
@@ -274,6 +275,7 @@ func (r *ResultResultSet) init() *ResultResultSet {
 				var value interface{}
 				attributevalue.Unmarshal(av, &value)
 				r.columnTypes[col] = reflect.TypeOf(value)
+				r.columnSourceTypes[col] = nameFromAttributeValue(av)
 			}
 		}
 	}
@@ -298,7 +300,7 @@ func (r *ResultResultSet) ColumnTypeScanType(index int) reflect.Type {
 
 // ColumnTypeDatabaseTypeName implements driver.RowsColumnTypeDatabaseTypeName/ColumnTypeDatabaseTypeName
 func (r *ResultResultSet) ColumnTypeDatabaseTypeName(index int) string {
-	return goTypeToDynamodbType(r.columnTypes[r.columnList[index]])
+	return r.columnSourceTypes[r.columnList[index]]
 }
 
 // Close implements driver.Rows/Close.


### PR DESCRIPTION
This PR changes the behavior of `ColumnTypeDatabaseTypeName` to use the DynamoDB `types.AttributeValue` value for determining the database type rather than introspecting the Golang type. This is important because it allows for helpful distinction across types (e.g. `L`, `SS`, `NS`, and `BS`)