### PR TITLE
Modified to columns in the order of the selected column list

### DIFF
--- a/module_test/stmt_document_test.go
+++ b/module_test/stmt_document_test.go
@@ -162,6 +162,56 @@ func Test_Query_Select_withLimit(t *testing.T) {
 	}
 }
 
+func Test_Query_Select_with_columns_selection(t *testing.T) {
+	testName := "Test_Query_Select_with_columns_selection"
+	db := _openDb(t, testName)
+	defer func() { _ = db.Close() }()
+	_initTest(db)
+
+	_, err := db.Exec(fmt.Sprintf(`CREATE TABLE %s WITH PK=app:string WITH SK=user:string WITH rcu=5 WITH wcu=5`, tblTestTemp))
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+	insData := [][]interface{}{
+		{"app", "user1", "Linux", true, 1.0},
+		{"app", "user2", "Windows", false, 2.3},
+		{"app", "user3", "MacOS", true, 4.56},
+	}
+	for _, data := range insData {
+		_, err = db.Exec(fmt.Sprintf(`INSERT INTO "%s" VALUE {'app': ?, 'user': ?, 'os': ?, 'active': ?, 'duration': ?}`, tblTestTemp), data...)
+		if err != nil {
+			t.Fatalf("%s failed: %s", testName+"/insert", err)
+		}
+	}
+
+	dbresult, err := db.Query(fmt.Sprintf(`SELECT * FROM "%s" WHERE app=?`, tblTestTemp), "app")
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName+"/select", err)
+	}
+	allRows, err := _fetchAllRows(dbresult)
+	if err != nil {
+		t.Fatalf("%s failed: %s", testName, err)
+	}
+	if len(allRows) != len(insData) {
+		t.Fatalf("%s failed: expected %#v row but received %#v", testName+"/select", len(insData), len(allRows))
+	}
+
+	dbresult, err = db.Query(fmt.Sprintf(`SELECT duration, app, os, active FROM "%s" WHERE app=? AND user=?`, tblTestTemp), "app", "user1")
+	if !dbresult.Next() {
+		t.Fatalf("%s failed: %s", testName+"/select", err)
+	}
+	var (
+		duration float64
+		app, os  string
+		active   bool
+	)
+	expected := []interface{}{1.0, "app", "Linux", true}
+	dbresult.Scan(&duration, &app, &os, &active)
+	if !reflect.DeepEqual([]interface{}{duration, app, os, active}, expected) {
+		t.Fatalf("%s failed: expected %#v but received %#v", testName+"/select", expected, []interface{}{duration, app, os, active})
+	}
+}
+
 func Test_Exec_Delete(t *testing.T) {
 	testName := "Test_Exec_Delete"
 	db := _openDb(t, testName)

--- a/module_test/stmt_document_test.go
+++ b/module_test/stmt_document_test.go
@@ -174,8 +174,6 @@ func Test_Query_Select_with_columns_selection(t *testing.T) {
 	}
 	insData := [][]interface{}{
 		{"app", "user1", "Linux", true, 1.0},
-		{"app", "user2", "Windows", false, 2.3},
-		{"app", "user3", "MacOS", true, 4.56},
 	}
 	for _, data := range insData {
 		_, err = db.Exec(fmt.Sprintf(`INSERT INTO "%s" VALUE {'app': ?, 'user': ?, 'os': ?, 'active': ?, 'duration': ?}`, tblTestTemp), data...)
@@ -196,7 +194,7 @@ func Test_Query_Select_with_columns_selection(t *testing.T) {
 		t.Fatalf("%s failed: expected %#v row but received %#v", testName+"/select", len(insData), len(allRows))
 	}
 
-	dbresult, err = db.Query(fmt.Sprintf(`SELECT duration, app, os, active FROM "%s" WHERE app=? AND user=?`, tblTestTemp), "app", "user1")
+	dbresult, err = db.Query(fmt.Sprintf(`SELECT "duration", "app", "os", "active" FROM "%s" WHERE "app"=? AND "user"=?`, tblTestTemp), "app", "user1")
 	if !dbresult.Next() {
 		t.Fatalf("%s failed: %s", testName+"/select", err)
 	}

--- a/stmt.go
+++ b/stmt.go
@@ -305,7 +305,9 @@ func (r *ResultResultSet) init() *ResultResultSet {
 			}
 		}
 	}
-
+	if len(r.columnList) > 0 {
+		return r
+	}
 	// save column names, sorted
 	r.columnList = make([]string, 0, len(colMap))
 	for col := range colMap {


### PR DESCRIPTION
This PR modifies `ResultResultSet.Columns` to be in the order of the selected column list.
However, when `SELECT * FROM...`  or `returnsvalue` will be sorted by column name as usual.

Issue #146 