### PR TITLE
Fix typo `CREATE GSI` as `CREATE LSI`

### DIFF
--- a/SQL_INDEX.md
+++ b/SQL_INDEX.md
@@ -1,7 +1,7 @@
 # godynamo - Supported statements for index
 
 - `DESCRIBE LSI`
-- `CREATE LSI`
+- `CREATE GSI`
 - `DESCRIBE GSI`
 - `ALTER GSI`
 - `DROP GSI`


### PR DESCRIPTION
Hi, @btnguyen2k 

Maybe this one is a typo, could you please check it out?

Thank you.