### PR TITLE
Replace global AWS config with per-connection Connector

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
   workflow_call:
 
 env:
-  COVER_PKG: 'github.com/btnguyen2k/godynamo'
+  COVER_PKG: 'github.com/grafana/godynamo/v2'
   AWS_REGION: 'us-east-1'
   AWS_ACCESS_KEY_ID: 'DUMMYID'
   AWS_SECRET_ACCESS_KEY: 'DUMMYKEY'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # godynamo
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/btnguyen2k/godynamo)](https://goreportcard.com/report/github.com/btnguyen2k/godynamo)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/btnguyen2k/godynamo)](https://pkg.go.dev/github.com/btnguyen2k/godynamo)
-[![Actions Status](https://github.com/btnguyen2k/godynamo/workflows/godynamo/badge.svg)](https://github.com/btnguyen2k/godynamo/actions)
-[![codecov](https://codecov.io/gh/btnguyen2k/godynamo/branch/main/graph/badge.svg)](https://codecov.io/gh/btnguyen2k/godynamo)
-[![Release](https://img.shields.io/github/release/btnguyen2k/godynamo.svg?style=flat-square)](RELEASE-NOTES.md)
+> **This is a Grafana fork of [btnguyen2k/godynamo](https://github.com/btnguyen2k/godynamo).**
+> It replaces global AWS configuration state with per-connection configuration via Go's `driver.Connector` interface, making it safe for multitenant use. See [Using `aws.Config`](#using-awsconfig) below.
 
 Go driver for [AWS DynamoDB](https://aws.amazon.com/dynamodb/) which can be used with the standard [database/sql](https://golang.org/pkg/database/sql/) package.
 
@@ -17,7 +14,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	_ "github.com/btnguyen2k/godynamo"
+	_ "github.com/grafana/godynamo/v2"
 )
 
 func main() {
@@ -65,39 +62,40 @@ Region=<aws-region>
 
 ## Using `aws.Config`:
 
-Since v1.3.0, `godynamo` supports using `aws.Config` to create the connection to DynamoDB:
+Use `godynamo.NewConnector` with `sql.OpenDB` to supply an `aws.Config` directly.
+This is the recommended approach for multitenant applications where each connection
+may need different credentials, regions, or endpoints, and also supports more
+advanced authentication options like assume role, EC2 instance IAM, etc.
 
 ```go
 package main
 
 import (
 	"database/sql"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/btnguyen2k/godynamo"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/grafana/godynamo/v2"
 )
 
 func main() {
-	driver := "godynamo"
-	awscfg := aws.Config{
-        Region: "<aws-region>",
-        Credentials: aws.StaticCredentialsProvider{
-            Value: aws.Credentials{
-                AccessKeyID:     "<access-key-id>",
-                SecretAccessKey: "<secret-key>",
-			},
-		},
-    }
-	godynamo.RegisterAWSConfig(awscfg)
-	
-	db, err := sql.Open(driver, "dummy")
-	if err != nil {
-		panic(err)
+	cfg := aws.Config{
+		Region: "<aws-region>",
+		Credentials: credentials.NewStaticCredentialsProvider(
+			"<access-key-id>", "<secret-key>", ""),
 	}
+	dsn := "Region=<aws-region>;AkId=<access-key-id>;SecretKey=<secret-key>"
+	connector := godynamo.NewConnector(dsn, &cfg)
+	db := sql.OpenDB(connector)
 	defer db.Close()
-	
+
 	// db instance is ready to use
 }
 ```
+
+When an `aws.Config` is provided, its credentials and region take precedence.
+DSN parameters such as `TimeoutMs` and `Endpoint` are still applied as defaults
+when not set in the `aws.Config`. Pass `nil` for the config to use only DSN credentials.
 
 ## Supported statements:
 
@@ -215,7 +213,7 @@ This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md
 
 ## Support and Contribution
 
-Feel free to create [pull requests](https://github.com/btnguyen2k/godynamo/pulls) or [issues](https://github.com/btnguyen2k/godynamo/issues) to report bugs or suggest new features.
+Feel free to create [pull requests](https://github.com/grafana/godynamo/pulls) or [issues](https://github.com/grafana/godynamo/issues) to report bugs or suggest new features.
 Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your bug or feature request as a new issue.
 
 If you find this project useful, please star it.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,37 @@
 # godynamo release notes
 
+## 2026-03-10 - v2.0.0 (Grafana fork)
+
+New module path: `github.com/grafana/godynamo/v2` (forked from `github.com/btnguyen2k/godynamo` v1.3.0).
+
+### Changed
+
+- BREAKING: Removed `RegisterAWSConfig` and `DeregisterAWSConfig` (global state)
+- BREAKING: `Driver.Open` no longer reads global AWS config; it uses only DSN credentials
+- Removed package-level `awsConfig` variable and associated mutex
+
+### Added/Refactoring
+
+- New `Connector` type implementing `database/sql/driver.Connector` for per-instance AWS configuration
+- New `NewConnector(dsn, *aws.Config)` constructor for use with `sql.OpenDB`
+- Extracted shared connection logic into internal `openConn` helper
+
+### Migration from v1.3.0
+
+Replace:
+```go
+godynamo.RegisterAWSConfig(cfg)
+db, err := sql.Open("godynamo", dsn)
+```
+
+With:
+```go
+connector := godynamo.NewConnector(dsn, &cfg)
+db := sql.OpenDB(connector)
+```
+
+If using DSN credentials only (no `aws.Config`), `sql.Open("godynamo", dsn)` continues to work unchanged.
+
 ## 2024-05-02 - v1.3.0
 
 ### Added/Refactoring

--- a/driver.go
+++ b/driver.go
@@ -1,14 +1,15 @@
 package godynamo
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"os"
 	"reflect"
 	"strings"
-	"sync"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -65,14 +66,10 @@ func parseConnString(connStr string) map[string]string {
 	return params
 }
 
-// Open implements driver.Driver/Open.
-//
-// connStr is expected in the following format:
-//
-//	Region=<region>;AkId=<aws-key-id>;Secret_Key=<aws-secret-key>[;Endpoint=<dynamodb-endpoint>][;TimeoutMs=<timeout-in-milliseconds>]
-//
-// If not supplied, default value for TimeoutMs is 10 seconds.
-func (d *Driver) Open(connStr string) (driver.Conn, error) {
+// openConn creates a driver.Conn from a DSN string and an optional aws.Config.
+// If cfg is non-nil, it is used to create the DynamoDB client (with DSN options merged in).
+// Otherwise, static credentials from the DSN are used directly.
+func openConn(connStr string, cfg *aws.Config) (driver.Conn, error) {
 	params := parseConnString(connStr)
 	timeoutMs := parseParamValue(params, reddo.TypeInt, func(val interface{}) bool {
 		return val.(int64) >= 0
@@ -87,7 +84,6 @@ func (d *Driver) Open(connStr string) (driver.Conn, error) {
 	}
 	endpoint := parseParamValue(params, reddo.TypeString, nil, "", []string{"ENDPOINT"}, []string{"AWS_DYNAMODB_ENDPOINT"}).(string)
 	if endpoint != "" {
-		//opts.EndpointResolver = dynamodb.EndpointResolverFromURL(endpoint)
 		opts.BaseEndpoint = aws.String(endpoint)
 		if strings.HasPrefix(endpoint, "http://") {
 			opts.EndpointOptions.DisableHTTPS = true
@@ -95,41 +91,49 @@ func (d *Driver) Open(connStr string) (driver.Conn, error) {
 	}
 	client := dynamodb.New(opts)
 
-	awsConfigLock.RLock()
-	defer awsConfigLock.RUnlock()
-	conf := awsConfig
-	if conf != nil {
-		client = dynamodb.NewFromConfig(*conf, mergeDynamoDBOptions(opts))
+	if cfg != nil {
+		client = dynamodb.NewFromConfig(*cfg, mergeDynamoDBOptions(opts))
 	}
 
 	return &Conn{client: client, timeout: time.Duration(timeoutMs) * time.Millisecond}, nil
 }
 
-// awsConfig is the AWS configuration to be used by the dynamodb client.
-var (
-	awsConfigLock = &sync.RWMutex{}
-	awsConfig     *aws.Config
-)
-
-// RegisterAWSConfig registers aws.Config to be used by the dynamodb client.
+// Open implements driver.Driver/Open.
 //
-// The following configurations do not apply even if they are set in aws.Config.
-//   - HTTPClient
+// connStr is expected in the following format:
 //
-// @Available since v1.3.0
-func RegisterAWSConfig(conf aws.Config) {
-	awsConfigLock.Lock()
-	defer awsConfigLock.Unlock()
-	awsConfig = &conf
+//	Region=<region>;AkId=<aws-key-id>;Secret_Key=<aws-secret-key>[;Endpoint=<dynamodb-endpoint>][;TimeoutMs=<timeout-in-milliseconds>]
+//
+// If not supplied, default value for TimeoutMs is 10 seconds.
+//
+// Open uses only the credentials provided in the connection string.
+// To use an aws.Config (e.g. for shared credentials), use NewConnector with sql.OpenDB instead.
+func (d *Driver) Open(connStr string) (driver.Conn, error) {
+	return openConn(connStr, nil)
 }
 
-// DeregisterAWSConfig removes the registered aws.Config.
-//
-// @Available since v1.3.0
-func DeregisterAWSConfig() {
-	awsConfigLock.Lock()
-	defer awsConfigLock.Unlock()
-	awsConfig = nil
+// Connector implements database/sql/driver.Connector for per-instance AWS configuration.
+// Use NewConnector and sql.OpenDB to create connections without global state.
+type Connector struct {
+	dsn       string
+	awsConfig *aws.Config
+}
+
+// NewConnector creates a Connector that holds per-instance AWS configuration.
+// Use sql.OpenDB(connector) instead of sql.Open("godynamo", dsn) to avoid global state.
+// If cfg is nil, static credentials from the DSN are used.
+func NewConnector(dsn string, cfg *aws.Config) *Connector {
+	return &Connector{dsn: dsn, awsConfig: cfg}
+}
+
+// Connect implements driver.Connector/Connect.
+func (c *Connector) Connect(_ context.Context) (driver.Conn, error) {
+	return openConn(c.dsn, c.awsConfig)
+}
+
+// Driver implements driver.Connector/Driver.
+func (c *Connector) Driver() driver.Driver {
+	return &Driver{}
 }
 
 // mergeDynamoDBOptions merges the provided dynamodb.Options into the default dynamodb.Options.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/btnguyen2k/godynamo
+module github.com/grafana/godynamo/v2
 
 go 1.18
 

--- a/module.go
+++ b/module.go
@@ -3,7 +3,7 @@ package godynamo
 
 const (
 	// Version holds the semantic version number of this module.
-	Version = "1.3.0"
+	Version = "2.0.0"
 )
 
 // This file contains module's metadata only, which is package level documentation and module Version string.

--- a/module_test/go.mod
+++ b/module_test/go.mod
@@ -1,8 +1,8 @@
 module godynamo_test
 
-go 1.18
+go 1.21
 
-replace github.com/btnguyen2k/godynamo => ../
+replace github.com/grafana/godynamo/v2 => ../
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.5
@@ -11,7 +11,7 @@ require (
 	github.com/aws/smithy-go v1.20.4
 	github.com/btnguyen2k/consu/reddo v0.1.9
 	github.com/btnguyen2k/consu/semita v0.1.5
-	github.com/btnguyen2k/godynamo v0.0.0-00010101000000-000000000000
+	github.com/grafana/godynamo/v2 v0.0.0-00010101000000-000000000000
 )
 
 require (

--- a/module_test/godynamo_test.go
+++ b/module_test/godynamo_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/btnguyen2k/consu/reddo"
-	"github.com/btnguyen2k/godynamo"
+	"github.com/grafana/godynamo/v2"
 	"os"
 	"reflect"
 	"strconv"
@@ -38,20 +38,17 @@ func Test_OpenDatabase(t *testing.T) {
 	}
 }
 
-func Test_OpenDatabase_With_AWSConfig_Endpoint(t *testing.T) {
-	testName := "Test_OpenDatabase_With_AWSConfig_Endpoint"
-	dbdriver := "godynamo"
+func Test_OpenDatabase_With_Connector_Endpoint(t *testing.T) {
+	testName := "Test_OpenDatabase_With_Connector_Endpoint"
 
 	dsnEndpoint := "http://1.2.3.4:1234/"
 	dsn := fmt.Sprintf("Region=dummy-region;AkId=dummy-key-id;SecretKey=dummy-key;Endpoint=%s", dsnEndpoint)
 
 	{
 		// without AWSConfig
-		db, err := sql.Open(dbdriver, dsn)
-		if err != nil {
-			t.Fatalf("%s failed: %s", testName+"/open", err)
-		}
-		_, err = db.QueryContext(context.Background(), "LIST TABLES")
+		connector := godynamo.NewConnector(dsn, nil)
+		db := sql.OpenDB(connector)
+		_, err := db.QueryContext(context.Background(), "LIST TABLES")
 		if err == nil {
 			t.Fatalf("%s failed: expected error", testName+"/query")
 		}
@@ -60,19 +57,15 @@ func Test_OpenDatabase_With_AWSConfig_Endpoint(t *testing.T) {
 		}
 	}
 
-	defer godynamo.DeregisterAWSConfig()
-
-	// with AWSConfig
+	// with AWSConfig that overrides endpoint
 	cfgEndpoint := "http://5.6.7.8:5678/"
-	godynamo.RegisterAWSConfig(aws.Config{
-		BaseEndpoint: aws.String(cfgEndpoint),
-	})
 	{
-		db, err := sql.Open(dbdriver, dsn)
-		if err != nil {
-			t.Fatalf("%s failed: %s", testName+"/open", err)
+		cfg := aws.Config{
+			BaseEndpoint: aws.String(cfgEndpoint),
 		}
-		_, err = db.QueryContext(context.Background(), "LIST TABLES")
+		connector := godynamo.NewConnector(dsn, &cfg)
+		db := sql.OpenDB(connector)
+		_, err := db.QueryContext(context.Background(), "LIST TABLES")
 		if err == nil {
 			t.Fatalf("%s failed: expected error", testName+"/query")
 		}
@@ -81,14 +74,12 @@ func Test_OpenDatabase_With_AWSConfig_Endpoint(t *testing.T) {
 		}
 	}
 
-	// with empty AWSConfig
-	godynamo.RegisterAWSConfig(aws.Config{})
+	// with empty AWSConfig (falls back to DSN endpoint)
 	{
-		db, err := sql.Open(dbdriver, dsn)
-		if err != nil {
-			t.Fatalf("%s failed: %s", testName+"/open", err)
-		}
-		_, err = db.QueryContext(context.Background(), "LIST TABLES")
+		cfg := aws.Config{}
+		connector := godynamo.NewConnector(dsn, &cfg)
+		db := sql.OpenDB(connector)
+		_, err := db.QueryContext(context.Background(), "LIST TABLES")
 		if err == nil {
 			t.Fatalf("%s failed: expected error", testName+"/query")
 		}
@@ -175,23 +166,29 @@ func TestDriver_Close(t *testing.T) {
 	}
 }
 
-func TestDriver_Open_With_AWSConfig(t *testing.T) {
-	testName := "TestDriver_Open_With_AWSConfig"
-	godynamo.RegisterAWSConfig(aws.Config{
+func TestDriver_Open_With_Connector(t *testing.T) {
+	testName := "TestDriver_Open_With_Connector"
+	url := strings.ReplaceAll(os.Getenv("AWS_DYNAMODB_URL"), `"`, "")
+	if url == "" {
+		t.Skipf("%s skipped", testName)
+	}
+
+	cfg := aws.Config{
 		Region: "us-west-2",
 		Credentials: credentials.NewStaticCredentialsProvider(
 			"abcdefg123456789", "abcdefg123456789", ""),
-	})
-	defer godynamo.DeregisterAWSConfig()
-	db := _openDb(t, testName)
+	}
+	connector := godynamo.NewConnector(url, &cfg)
+	db := sql.OpenDB(connector)
 	defer func() { _ = db.Close() }()
 	if err := db.Ping(); err != nil {
 		t.Fatalf("%s failed: %s", testName, err)
 	}
 
 	// with empty aws.Config
-	godynamo.RegisterAWSConfig(aws.Config{})
-	dbWithEmptyAWSConfig := _openDb(t, testName)
+	emptyCfg := aws.Config{}
+	connectorEmpty := godynamo.NewConnector(url, &emptyCfg)
+	dbWithEmptyAWSConfig := sql.OpenDB(connectorEmpty)
 	defer func() { _ = dbWithEmptyAWSConfig.Close() }()
 	if err := dbWithEmptyAWSConfig.Ping(); err != nil {
 		t.Fatalf("%s failed: %s", testName, err)

--- a/module_test/stmt_document_test.go
+++ b/module_test/stmt_document_test.go
@@ -3,7 +3,7 @@ package godynamo_test
 import (
 	"fmt"
 	"github.com/aws/smithy-go"
-	"github.com/btnguyen2k/godynamo"
+	"github.com/grafana/godynamo/v2"
 	"reflect"
 	"strings"
 	"testing"

--- a/module_test/stmt_test.go
+++ b/module_test/stmt_test.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-	"github.com/btnguyen2k/godynamo"
+	"github.com/grafana/godynamo/v2"
 	"reflect"
 	"strconv"
 	"strings"

--- a/module_test/tx_test.go
+++ b/module_test/tx_test.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/btnguyen2k/godynamo"
+	"github.com/grafana/godynamo/v2"
 	"reflect"
 	"sort"
 	"strconv"

--- a/module_test/utils_test.go
+++ b/module_test/utils_test.go
@@ -3,7 +3,7 @@ package godynamo_test
 import (
 	"context"
 	"fmt"
-	"github.com/btnguyen2k/godynamo"
+	"github.com/grafana/godynamo/v2"
 	"testing"
 	"time"
 )

--- a/module_test_real/go.mod
+++ b/module_test_real/go.mod
@@ -1,14 +1,14 @@
 module godynamo_test
 
-go 1.18
+go 1.21
 
-replace github.com/btnguyen2k/godynamo => ../
+replace github.com/grafana/godynamo/v2 => ../
 
 require (
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.34.9
 	github.com/btnguyen2k/consu/reddo v0.1.9
 	github.com/btnguyen2k/consu/semita v0.1.5
-	github.com/btnguyen2k/godynamo v0.0.0-00010101000000-000000000000
+	github.com/grafana/godynamo/v2 v0.0.0-00010101000000-000000000000
 )
 
 require (

--- a/module_test_real/godynamo_test.go
+++ b/module_test_real/godynamo_test.go
@@ -2,7 +2,7 @@ package godynamo_test
 
 import (
 	"database/sql"
-	_ "github.com/btnguyen2k/godynamo"
+	_ "github.com/grafana/godynamo/v2"
 	"os"
 	"strings"
 	"testing"

--- a/module_test_real/stmt_table_test.go
+++ b/module_test_real/stmt_table_test.go
@@ -3,7 +3,7 @@ package godynamo_test
 import (
 	"context"
 	"fmt"
-	"github.com/btnguyen2k/godynamo"
+	"github.com/grafana/godynamo/v2"
 	"strings"
 	"testing"
 	"time"

--- a/module_test_real/stmt_test.go
+++ b/module_test_real/stmt_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-	"github.com/btnguyen2k/godynamo"
+	"github.com/grafana/godynamo/v2"
 	"reflect"
 	"strconv"
 	"strings"


### PR DESCRIPTION
## Summary

- Adds a `Connector` type implementing `driver.Connector` for per-instance AWS configuration, enabling safe concurrent use with multiple AWS accounts, regions, or credential sources via `sql.OpenDB`
- Removes global `RegisterAWSConfig`/`DeregisterAWSConfig` and associated package-level state
- `Driver.Open` now uses only DSN credentials; `aws.Config` must be provided via `NewConnector`
- Module path changed to `github.com/grafana/godynamo/v2`

### Migration

```go
// Before (v1)
godynamo.RegisterAWSConfig(cfg)
db, err := sql.Open("godynamo", dsn)

// After (v2)
connector := godynamo.NewConnector(dsn, &cfg)
db := sql.OpenDB(connector)
```

`sql.Open("godynamo", dsn)` still works for DSN-only credentials.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `module_test/` tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)